### PR TITLE
Remove short confused smiley from replace list

### DIFF
--- a/emoji.py
+++ b/emoji.py
@@ -52,7 +52,6 @@ EMOTICON_TO_EMOJI_ALIASES = {
     ':(': ':disappointed:',
     '):': ':disappointed:',
     ':-(': ':disappointed:',
-    ':/': ':confused:',
     ':-/': ':confused:',
     ':\\': ':confused:',
     ':-\\': ':confused:',


### PR DESCRIPTION
The short confused smiley :/ interferred with pasing links in HexChat. This commit removes this smiley from the list.

Fixes https://github.com/alexandrevicenzi/hexchat-emoji/issues/2

