### PR TITLE
Remove 8) to emoji translation

### DIFF
--- a/emoji.py
+++ b/emoji.py
@@ -41,7 +41,6 @@ EMOTICON_TO_EMOJI = True
 EMOTICON_TO_EMOJI_ALIASES = {
     "<3": ":heart:",
     "</3": ":broken_heart:",
-    "8)": ":sunglasses:",
     "8-)": ":sunglasses:",
     "D:": ":anguished:",
     ":'(": ":cry:",


### PR DESCRIPTION
IME this is the emoji that's most likely to be unintentionally triggered to the annoyance of the writer. There are already two other, unambiguous ways to achieve this result, so this one seems removable to me.